### PR TITLE
Dxc fix verifyrootsignature option

### DIFF
--- a/include/dxc/Support/dxcapi.use.h
+++ b/include/dxc/Support/dxcapi.use.h
@@ -104,13 +104,13 @@ void IFT_Data(HRESULT hr, _In_opt_ LPCWSTR data);
 void EnsureEnabled(DxcDllSupport &dxcSupport);
 void ReadFileIntoBlob(DxcDllSupport &dxcSupport, _In_ LPCWSTR pFileName,
                       _Outptr_ IDxcBlobEncoding **ppBlobEncoding);
-void WriteBlobToConsole(_In_opt_ IDxcBlob *pBlob, FILE* streamType = stdout);
+void WriteBlobToConsole(_In_opt_ IDxcBlob *pBlob, DWORD streamType = STD_OUTPUT_HANDLE);
 void WriteBlobToFile(_In_opt_ IDxcBlob *pBlob, _In_ LPCWSTR pFileName);
 void WriteBlobToHandle(_In_opt_ IDxcBlob *pBlob, HANDLE hFile, _In_opt_ LPCWSTR pFileName);
 void WriteUtf8ToConsole(_In_opt_count_(charCount) const char *pText,
-                        int charCount, FILE* streamType = stdout);
+                        int charCount, DWORD streamType = STD_OUTPUT_HANDLE);
 void WriteUtf8ToConsoleSizeT(_In_opt_count_(charCount) const char *pText,
-                             size_t charCount, FILE* streamType = stdout);
+                             size_t charCount, DWORD streamType = STD_OUTPUT_HANDLE);
 void WriteOperationErrorsToConsole(_In_ IDxcOperationResult *pResult,
                                    bool outputWarnings);
 void WriteOperationResultToConsole(_In_ IDxcOperationResult *pRewriteResult,

--- a/include/dxc/Support/dxcapi.use.h
+++ b/include/dxc/Support/dxcapi.use.h
@@ -104,13 +104,13 @@ void IFT_Data(HRESULT hr, _In_opt_ LPCWSTR data);
 void EnsureEnabled(DxcDllSupport &dxcSupport);
 void ReadFileIntoBlob(DxcDllSupport &dxcSupport, _In_ LPCWSTR pFileName,
                       _Outptr_ IDxcBlobEncoding **ppBlobEncoding);
-void WriteBlobToConsole(_In_opt_ IDxcBlob *pBlob);
+void WriteBlobToConsole(_In_opt_ IDxcBlob *pBlob, FILE* streamType = stdout);
 void WriteBlobToFile(_In_opt_ IDxcBlob *pBlob, _In_ LPCWSTR pFileName);
 void WriteBlobToHandle(_In_opt_ IDxcBlob *pBlob, HANDLE hFile, _In_opt_ LPCWSTR pFileName);
 void WriteUtf8ToConsole(_In_opt_count_(charCount) const char *pText,
-                        int charCount);
+                        int charCount, FILE* streamType = stdout);
 void WriteUtf8ToConsoleSizeT(_In_opt_count_(charCount) const char *pText,
-                             size_t charCount);
+                             size_t charCount, FILE* streamType = stdout);
 void WriteOperationErrorsToConsole(_In_ IDxcOperationResult *pResult,
                                    bool outputWarnings);
 void WriteOperationResultToConsole(_In_ IDxcOperationResult *pRewriteResult,

--- a/lib/DxcSupport/dxcapi.use.cpp
+++ b/lib/DxcSupport/dxcapi.use.cpp
@@ -76,7 +76,7 @@ void WriteOperationErrorsToConsole(_In_ IDxcOperationResult *pResult,
     CComPtr<IDxcBlobEncoding> pErrors;
     IFT(pResult->GetErrorBuffer(&pErrors));
     if (pErrors.p != nullptr) {
-      WriteBlobToConsole(pErrors);
+      WriteBlobToConsole(pErrors, stderr);
     }
   }
 }
@@ -87,16 +87,16 @@ void WriteOperationResultToConsole(_In_ IDxcOperationResult *pRewriteResult,
 
   CComPtr<IDxcBlob> pBlob;
   IFT(pRewriteResult->GetResult(&pBlob));
-  WriteBlobToConsole(pBlob);
+  WriteBlobToConsole(pBlob, stdout);
 }
 
-void WriteBlobToConsole(_In_opt_ IDxcBlob *pBlob) {
+void WriteBlobToConsole(_In_opt_ IDxcBlob *pBlob, FILE* streamType) {
   if (pBlob == nullptr) {
     return;
   }
 
   // Assume UTF-8 for now, which is typically the case for dxcompiler ouput.
-  WriteUtf8ToConsoleSizeT((char *)pBlob->GetBufferPointer(), pBlob->GetBufferSize());
+  WriteUtf8ToConsoleSizeT((char *)pBlob->GetBufferPointer(), pBlob->GetBufferSize(), streamType);
 }
 
 void WriteBlobToFile(_In_opt_ IDxcBlob *pBlob, _In_ LPCWSTR pFileName) {
@@ -125,7 +125,7 @@ void WriteBlobToHandle(_In_opt_ IDxcBlob *pBlob, _In_ HANDLE hFile, _In_opt_ LPC
 }
 
 void WriteUtf8ToConsole(_In_opt_count_(charCount) const char *pText,
-                        int charCount) {
+                        int charCount, FILE* streamType) {
   if (charCount == 0 || pText == nullptr) {
     return;
   }
@@ -139,19 +139,19 @@ void WriteUtf8ToConsole(_In_opt_count_(charCount) const char *pText,
 
   std::string consoleMessage;
   Unicode::UTF16ToConsoleString(utf16Message, &consoleMessage, &lossy);
-  printf("%s\n", consoleMessage.c_str());
+  fprintf(streamType, "%s\n", consoleMessage.c_str());
   delete[] utf16Message;
 }
 
 void WriteUtf8ToConsoleSizeT(_In_opt_count_(charCount) const char *pText,
-  size_t charCount) {
+  size_t charCount, FILE* streamType) {
   if (charCount == 0) {
     return;
   }
 
   int charCountInt;
   IFT(SizeTToInt(charCount, &charCountInt));
-  WriteUtf8ToConsole(pText, charCountInt);
+  WriteUtf8ToConsole(pText, charCountInt, streamType);
 }
 
 } // namespace dxc

--- a/lib/DxcSupport/dxcapi.use.cpp
+++ b/lib/DxcSupport/dxcapi.use.cpp
@@ -76,7 +76,7 @@ void WriteOperationErrorsToConsole(_In_ IDxcOperationResult *pResult,
     CComPtr<IDxcBlobEncoding> pErrors;
     IFT(pResult->GetErrorBuffer(&pErrors));
     if (pErrors.p != nullptr) {
-      WriteBlobToConsole(pErrors, stderr);
+      WriteBlobToConsole(pErrors, STD_ERROR_HANDLE);
     }
   }
 }
@@ -87,10 +87,10 @@ void WriteOperationResultToConsole(_In_ IDxcOperationResult *pRewriteResult,
 
   CComPtr<IDxcBlob> pBlob;
   IFT(pRewriteResult->GetResult(&pBlob));
-  WriteBlobToConsole(pBlob, stdout);
+  WriteBlobToConsole(pBlob, STD_OUTPUT_HANDLE);
 }
 
-void WriteBlobToConsole(_In_opt_ IDxcBlob *pBlob, FILE* streamType) {
+void WriteBlobToConsole(_In_opt_ IDxcBlob *pBlob, DWORD streamType) {
   if (pBlob == nullptr) {
     return;
   }
@@ -125,7 +125,7 @@ void WriteBlobToHandle(_In_opt_ IDxcBlob *pBlob, _In_ HANDLE hFile, _In_opt_ LPC
 }
 
 void WriteUtf8ToConsole(_In_opt_count_(charCount) const char *pText,
-                        int charCount, FILE* streamType) {
+                        int charCount, DWORD streamType) {
   if (charCount == 0 || pText == nullptr) {
     return;
   }
@@ -139,12 +139,21 @@ void WriteUtf8ToConsole(_In_opt_count_(charCount) const char *pText,
 
   std::string consoleMessage;
   Unicode::UTF16ToConsoleString(utf16Message, &consoleMessage, &lossy);
-  fprintf(streamType, "%s\n", consoleMessage.c_str());
+  if (streamType == STD_OUTPUT_HANDLE) {
+    fprintf(stdout, "%s\n", consoleMessage.c_str());
+  }
+  else if (streamType == STD_ERROR_HANDLE) {
+    fprintf(stderr, "%s\n", consoleMessage.c_str());
+  }
+  else {
+    throw hlsl::Exception(E_INVALIDARG);
+  }
+
   delete[] utf16Message;
 }
 
 void WriteUtf8ToConsoleSizeT(_In_opt_count_(charCount) const char *pText,
-  size_t charCount, FILE* streamType) {
+  size_t charCount, DWORD streamType) {
   if (charCount == 0) {
     return;
   }

--- a/tools/clang/tools/dxc/dxc.cpp
+++ b/tools/clang/tools/dxc/dxc.cpp
@@ -77,7 +77,7 @@ private:
   DxcOpts &m_Opts;
   DxcDllSupport &m_dxcSupport;
 
-  void ActOnBlob(IDxcBlob *pBlob);
+  int ActOnBlob(IDxcBlob *pBlob);
   void UpdatePart(IDxcBlob *pBlob, IDxcBlob **ppResult);
   bool UpdatePartRequired();
   void WriteHeader(IDxcBlobEncoding *pDisassembly, IDxcBlob *pCode,
@@ -88,7 +88,7 @@ private:
   HRESULT GetDxcDiaTable(IDxcLibrary *pLibrary, IDxcBlob *pTargetBlob, IDiaTable **ppTable, LPCWSTR tableName);
   HRESULT FindModuleBlob(hlsl::DxilFourCC fourCC, IDxcBlob *pSource, IDxcLibrary *pLibrary, IDxcBlob **ppTargetBlob);
   void ExtractRootSignature(IDxcBlob *pBlob, IDxcBlob **ppResult);
-  void VerifyRootSignature();
+  int VerifyRootSignature();
 
 public:
   DxcContext(DxcOpts &Opts, DxcDllSupport &dxcSupport)
@@ -96,7 +96,7 @@ public:
 
   int  Compile();
   void Recompile(IDxcBlob *pSource, IDxcLibrary *pLibrary, IDxcCompiler *pCompiler, std::vector<LPCWSTR> &args, IDxcOperationResult **pCompileResult);
-  void DumpBinary();
+  int DumpBinary();
   void Preprocess();
 };
 
@@ -134,11 +134,12 @@ static void WritePartToFile(IDxcBlob *pBlob, hlsl::DxilFourCC CC,
 
 // This function is called either after the compilation is done or /dumpbin option is provided
 // Performing options that are used to process dxil container.
-void DxcContext::ActOnBlob(IDxcBlob *pBlob) {
+int DxcContext::ActOnBlob(IDxcBlob *pBlob) {
+  int retVal = 0;
   // Text output.
   if (m_Opts.AstDump || m_Opts.OptDump) {
     WriteBlobToConsole(pBlob);
-    return;
+    return retVal;
   }
 
   // Write the output blob.
@@ -153,7 +154,7 @@ void DxcContext::ActOnBlob(IDxcBlob *pBlob) {
 
   // Verify Root Signature
   if (!m_Opts.VerifyRootSignatureSource.empty()) {
-    VerifyRootSignature();
+    return VerifyRootSignature();
   }
 
   // Extract and write the PDB/debug information.
@@ -186,7 +187,7 @@ void DxcContext::ActOnBlob(IDxcBlob *pBlob) {
        m_Opts.VerifyRootSignatureSource.empty() && !m_Opts.ExtractRootSignature);
 
   if (!needDisassembly)
-    return;
+     return retVal;
 
   CComPtr<IDxcCompiler> pCompiler;
   IFT(m_dxcSupport.CreateInstance(CLSID_DxcCompiler, &pCompiler));
@@ -204,6 +205,7 @@ void DxcContext::ActOnBlob(IDxcBlob *pBlob) {
   } else {
     WriteBlobToConsole(pDisassembleResult);
   }
+  return retVal;
 }
 
 // Given a dxil container, update the dxil container by processing container specific options.
@@ -358,7 +360,7 @@ void DxcContext::ExtractRootSignature(IDxcBlob *pBlob, IDxcBlob **ppResult) {
   *ppResult = pResult.Detach();
 }
 
-void DxcContext::VerifyRootSignature() {
+int DxcContext::VerifyRootSignature() {
   // Get dxil container from file
   CComPtr<IDxcBlobEncoding> pSource;
   ReadFileIntoBlob(m_dxcSupport, StringRefUtf16(m_Opts.InputFile), &pSource);
@@ -396,9 +398,11 @@ void DxcContext::VerifyRootSignature() {
     else {
       WriteOperationErrorsToConsole(pOperationResult, m_Opts.OutputWarnings);
     }
+    return 1;
   }
   else {
     printf("root signature verification succeeded.");
+    return 0;
   }
 }
 
@@ -657,10 +661,10 @@ int DxcContext::Compile() {
   return status;
 }
 
-void DxcContext::DumpBinary() {
+int DxcContext::DumpBinary() {
   CComPtr<IDxcBlobEncoding> pSource;
   ReadFileIntoBlob(m_dxcSupport, StringRefUtf16(m_Opts.InputFile), &pSource);
-  ActOnBlob(pSource.p);
+  return ActOnBlob(pSource.p);
 }
 
 void DxcContext::Preprocess() {
@@ -870,7 +874,7 @@ int __cdecl wmain(int argc, const wchar_t **argv_) {
     }
     else if (dxcOpts.DumpBin) {
       pStage = "Dumping existing binary";
-      context.DumpBinary();
+      retVal = context.DumpBinary();
     }
     else {
       pStage = "Compilation";
@@ -912,7 +916,7 @@ int __cdecl wmain(int argc, const wchar_t **argv_) {
         msg = printBuffer;
       }
 
-      WriteUtf8ToConsoleSizeT(msg, strlen(msg));
+      WriteUtf8ToConsoleSizeT(msg, strlen(msg), stderr);
       printf("\n");
     } catch (...) {
       printf("%s failed - unable to retrieve error message.\n", pStage);

--- a/tools/clang/tools/dxc/dxc.cpp
+++ b/tools/clang/tools/dxc/dxc.cpp
@@ -916,7 +916,7 @@ int __cdecl wmain(int argc, const wchar_t **argv_) {
         msg = printBuffer;
       }
 
-      WriteUtf8ToConsoleSizeT(msg, strlen(msg), stderr);
+      WriteUtf8ToConsoleSizeT(msg, strlen(msg), STD_ERROR_HANDLE);
       printf("\n");
     } catch (...) {
       printf("%s failed - unable to retrieve error message.\n", pStage);

--- a/tools/clang/tools/dxcompiler/dxcontainerbuilder.cpp
+++ b/tools/clang/tools/dxcompiler/dxcontainerbuilder.cpp
@@ -24,6 +24,9 @@
 
 using namespace hlsl;
 
+// This declaration is used for the locally-linked validator.
+HRESULT CreateDxcValidator(_In_ REFIID riid, _Out_ LPVOID *ppv);
+
 class DxcContainerBuilder : public IDxcContainerBuilder {
 public:
   __override HRESULT STDMETHODCALLTYPE Load(_In_ IDxcBlob *pDxilContainerHeader); // Loads DxilContainer to the builder
@@ -36,7 +39,7 @@ public:
     return DoBasicQueryInterface<IDxcContainerBuilder>(this, riid, ppvObject);
   }
 
-  DxcContainerBuilder(const char *warning) : m_dwRef(0), m_parts(), m_pContainer(), m_warning(warning) {}
+  DxcContainerBuilder(const char *warning) : m_dwRef(0), m_parts(), m_pContainer(), m_warning(warning), m_RequireValidation(false) {}
 
 private:
   DXC_MICROCOM_REF_FIELD(m_dwRef)
@@ -52,6 +55,7 @@ private:
   PartList m_parts;
   CComPtr<IDxcBlob> m_pContainer; 
   const char *m_warning;
+  bool m_RequireValidation;
 
   UINT32 ComputeContainerSize();
   HRESULT UpdateContainerHeader(AbstractMemoryStream *pStream, uint32_t containerSize);
@@ -95,6 +99,9 @@ HRESULT STDMETHODCALLTYPE DxcContainerBuilder::AddPart(_In_ UINT32 fourCC, _In_ 
     });
     IFTBOOL(it == m_parts.end(), DXC_E_DUPLICATE_PART);
     m_parts.emplace_back(DxilPart(fourCC, pSource));
+    if (fourCC == DxilFourCC::DFCC_RootSignature) {
+      m_RequireValidation = true;
+    }
     return S_OK;
   }
   CATCH_CPP_RETURN_HRESULT();
@@ -137,9 +144,40 @@ HRESULT STDMETHODCALLTYPE DxcContainerBuilder::SerializeContainer(_Out_ IDxcOper
     // Update Parts
     IFT(UpdateParts(pMemoryStream));
 
-    CComPtr<IDxcBlobEncoding> pError;
-    DxcCreateBlobWithEncodingOnHeapCopy(m_warning, strlen(m_warning), CP_UTF8, &pError);
-    DxcOperationResult::CreateFromResultErrorStatus(pResult, pError, S_OK, ppResult);
+    CComPtr<IDxcBlobEncoding> pErrorBlob;
+    HRESULT valHR = S_OK;
+    if (m_RequireValidation) {
+      CComPtr<IDxcValidator> pValidator;
+      CComPtr<IDxcLibrary> pLibrary;
+      IFT(CreateDxcValidator(IID_PPV_ARGS(&pValidator)));
+      CComPtr<IDxcOperationResult> pValidationResult;
+      IFT(pValidator->Validate(pResult, DxcValidatorFlags_RootSignatureOnly, &pValidationResult));
+      IFT(pValidationResult->GetStatus(&valHR));
+      if (FAILED(valHR)) {
+        CComPtr<IMalloc> pErrorMalloc;
+        CComPtr<AbstractMemoryStream> pErrorOutputStream;
+        CComPtr<IDxcBlob> pErrorResult;
+        IFT(CoGetMalloc(1, &pErrorMalloc));
+        IFT(CreateMemoryStream(pErrorMalloc, &pErrorOutputStream));
+        IFT(pErrorOutputStream.QueryInterface(&pErrorResult));
+        
+        // Combine existing warnings and errors from validation
+        CComPtr<IDxcBlobEncoding> pValError;
+        IFT(pValidationResult->GetErrorBuffer(&pValError));
+        IFT(pErrorOutputStream->Reserve(strlen(m_warning) + pValError->GetBufferSize()));
+        ULONG cbWritten;
+        IFT(pErrorOutputStream->Write(m_warning, strlen(m_warning), &cbWritten));
+        IFT(pErrorOutputStream->Write(pValError->GetBufferPointer(), pValError->GetBufferSize(), &cbWritten));
+        DxcCreateBlobWithEncodingSet(pErrorResult, CP_UTF8, &pErrorBlob);
+      }
+      else {
+        DxcCreateBlobWithEncodingOnHeapCopy(m_warning, strlen(m_warning), CP_UTF8, &pErrorBlob);
+      }
+    }
+    else {
+      DxcCreateBlobWithEncodingOnHeapCopy(m_warning, strlen(m_warning), CP_UTF8, &pErrorBlob);
+    }
+    DxcOperationResult::CreateFromResultErrorStatus(pResult, pErrorBlob, valHR, ppResult);
     return S_OK;
   }
   CATCH_CPP_RETURN_HRESULT();
@@ -195,7 +233,7 @@ HRESULT CreateDxcContainerBuilder(_In_ REFIID riid, _Out_ LPVOID *ppv) {
   const char *warning;
   HRESULT hr = DxilLibCreateInstance(CLSID_DxcContainerBuilder, (IDxcContainerBuilder**)ppv);
   if (FAILED(hr)) {
-    warning = "Unable to create container builder from dxil.dll, fallback to built-in.";
+    warning = "Unable to create container builder from dxil.dll, fallback to built-in.\n";
   }
   else {
     return hr;

--- a/tools/clang/tools/dxcompiler/dxcontainerbuilder.cpp
+++ b/tools/clang/tools/dxcompiler/dxcontainerbuilder.cpp
@@ -233,7 +233,7 @@ HRESULT CreateDxcContainerBuilder(_In_ REFIID riid, _Out_ LPVOID *ppv) {
   const char *warning;
   HRESULT hr = DxilLibCreateInstance(CLSID_DxcContainerBuilder, (IDxcContainerBuilder**)ppv);
   if (FAILED(hr)) {
-    warning = "Unable to create container builder from dxil.dll, fallback to built-in.\n";
+    warning = "Unable to create container builder from dxil.dll. Resulting container will not be signed.\n";
   }
   else {
     return hr;

--- a/tools/clang/tools/dxcompiler/dxcvalidator.cpp
+++ b/tools/clang/tools/dxcompiler/dxcvalidator.cpp
@@ -242,7 +242,7 @@ HRESULT DxcValidator::RunRootSignatureValidation(
   const DxilProgramHeader *pProgramHeader = GetDxilProgramHeader(pDxilContainer, DFCC_DXIL);
   const DxilPartHeader *pPSVPart = GetDxilPartByType(pDxilContainer, DFCC_PipelineStateValidation);
   const DxilPartHeader *pRSPart = GetDxilPartByType(pDxilContainer, DFCC_RootSignature);
-  IFRBOOL(!pPSVPart || !pRSPart, DXC_E_MISSING_PART);
+  IFRBOOL(pPSVPart && pRSPart, DXC_E_MISSING_PART);
   try {
     RootSignatureHandle RSH;
     RSH.LoadSerialized((const uint8_t*)GetDxilPartData(pRSPart), pRSPart->PartSize);

--- a/utils/hct/hcttest.cmd
+++ b/utils/hct/hcttest.cmd
@@ -119,9 +119,9 @@ if "%TEST_CLANG%"=="1" (
   )
 
   copy /y %HLSL_SRC_DIR%\utils\hct\smoke.hlsl %TEST_DIR%\smoke.hlsl
-  call %HLSL_SRC_DIR%\utils\hct\hcttestcmds.cmd %TEST_DIR%
+  call %HLSL_SRC_DIR%\utils\hct\hcttestcmds.cmd %TEST_DIR% %HLSL_SRC_DIR%\tools\clang\test\HLSL
   if errorlevel 1 (
-    echo Failed - %HLSL_SRC_DIR%\utils\hct\hcttestcmds.cmd %TEST_DIR%
+    echo Failed - %HLSL_SRC_DIR%\utils\hct\hcttestcmds.cmd %TEST_DIR% %HLSL_SRC_DIR%\tools\clang\test\HLSL
     exit /b 1
   )
 )

--- a/utils/hct/hcttestcmds.cmd
+++ b/utils/hct/hcttestcmds.cmd
@@ -5,6 +5,11 @@ if "%1"=="" (
   exit /b 1
 )
 
+if "%2"=="" (
+  echo Second argument to hcttestcmds should be the absolute path to tools\clang\test\HLSL
+  exit /b 1
+)
+
 echo Testing command line programs at %1 ...
 
 setlocal
@@ -15,25 +20,28 @@ echo Smoke test for dxr command line program ...
 dxr.exe -remove-unused-globals smoke.hlsl -Emain 1> nul
 if %errorlevel% neq  0 (
   echo Failed - %CD%\dxr.exe -remove-unused-globals %CD%\smoke.hlsl -Emain
+  call :cleanup 2>nul
   exit /b 1
 )
-
 
 dxc.exe /T ps_6_0 smoke.hlsl /Fc smoke.hlsl.c 1>nul
 if %errorlevel% neq 0 (
   echo Failed - %CD%\dxc.exe /T ps_6_0 smoke.hlsl /Fc %CD%\smoke.hlsl.c
+  call :cleanup 2>nul
   exit /b 1
 )
 
-dxc.exe /T ps_6_0 smoke.hlsl /Zi /Fd smoke.hlsl.d 2>nul
+dxc.exe /T ps_6_0 smoke.hlsl /Zi /Fd smoke.hlsl.d 1>nul
 if %errorlevel% neq 0 (
   echo Failed - %CD%\dxc.exe /T ps_6_0 smoke.hlsl /Zi /Fd %CD%\smoke.hlsl.d
+  call :cleanup 2>nul
   exit /b 1
 )
 
 dxc.exe /T ps_6_0 smoke.hlsl /Fe smoke.hlsl.e 1>nul
 if %errorlevel% neq 0 (
   echo Failed - %CD%\dxc.exe /T ps_6_0 smoke.hlsl /Fe %CD%\smoke.hlsl.e
+  call :cleanup 2>nul
   exit /b 1
 )
 
@@ -41,95 +49,111 @@ echo Smoke test for dxc command line program ...
 dxc.exe /T ps_6_0 smoke.hlsl /Fh smoke.hlsl.h /Vn g_myvar 1> nul
 if %errorlevel% neq 0 (
   echo Failed - %CD%\dxc.exe /T ps_6_0 %CD%\smoke.hlsl /Fh %CD%\smoke.hlsl.h /Vn g_myvar
+  call :cleanup 2>nul
   exit /b 1
 )
 findstr g_myvar %CD%\smoke.hlsl.h 1>nul
 if %errorlevel% neq 0 (
   echo Failed to find the variable g_myvar in %CD%\smoke.hlsl.h
   echo Debug with start devenv /debugexe %CD%\dxc.exe /T ps_6_0 %CD%\smoke.hlsl /Fh %CD%\smoke.hlsl.h /Vn g_myvar
+  call :cleanup 2>nul
   exit /b 1
 )
 findstr "0x44, 0x58" %CD%\smoke.hlsl.h 1>nul
 if %errorlevel% neq 0 (
   echo Failed to find the bytecode for DXBC container in %CD%\smoke.hlsl.h
+  call :cleanup 2>nul
   exit /b 1
 )
 
 dxc.exe smoke.hlsl /P preprocessed.hlsl 1>nul
 if %errorlevel% neq 0 (
   echo Failed to preprocess smoke.hlsl
+  call :cleanup 2>nul
   exit /b 1
 )
 
 dxc.exe /T ps_6_0 smoke.hlsl -force_rootsig_ver rootsig_1_0 1>nul
 if %errorlevel% neq 0 (
   echo Failed to compile with forcing rootsignature rootsig_1_0
+  call :cleanup 2>nul
   exit /b 1
 )
 
 dxc.exe /T ps_6_0 smoke.hlsl -force_rootsig_ver rootsig_1_1 1>nul
 if %errorlevel% neq 0 (
   echo Failed to compile with forcing rootsignature rootsig_1_1
+  call :cleanup 2>nul
   exit /b 1
 )
 
 dxc.exe /T ps_6_0 smoke.hlsl -force_rootsig_ver rootsig_2_0 2>nul
 if %errorlevel% equ 0 (
   echo rootsig_2_0 is not supported but compilation passed
+  call :cleanup 2>nul
   exit /b 1
 )
 
 dxc.exe /T ps_6_0 smoke.hlsl /HV 2016 1>nul
 if %errorlevel% neq 0 (
   echo Failed to compile with HLSL version 2016
+  call :cleanup 2>nul
   exit /b 1
 )
 
 dxc.exe /T ps_6_0 smoke.hlsl /HV 2015 2>nul
 if %errorlevel% equ 0 (
   echo Unsupported HLSL version 2015 should fail but did not fail
+  call :cleanup 2>nul
   exit /b 1
 )
 
 dxc.exe /T ps_6_0 smoke.hlsl /Zi /Fo smoke.cso 1> nul
 if %errorlevel% neq 0 (
   echo Failed to compile to binary object from %CD%\smoke.hlsl
+  call :cleanup 2>nul
   exit /b 1
 )
 
 dxc.exe /T ps_6_0 smoke.hlsl /Zi /Fo smoke.cso /Cc /Ni /No /Lx 1> nul
 if %errorlevel% neq 0 (
   echo Failed to compile to binary object from %CD%\smoke.hlsl with disassembly options
+  call :cleanup 2>nul
   exit /b 1
 )
 
 dxc.exe -dumpbin smoke.cso 1> nul
 if %errorlevel% neq 0 (
   echo Failed to disassemble binary object from %CD%\smoke.hlsl
+  call :cleanup 2>nul
   exit /b 1
 )
 
 dxc.exe smoke.cso /recompile 1>nul
 if %errorlevel% neq 0 (
   echo Failed to recompile binary object compiled from %CD%\smoke.hlsl
+  call :cleanup 2>nul
   exit /b 1
 )
 
 dxc.exe smoke.cso /recompile /T ps_6_0 /E main 1>nul
 if %errorlevel% neq 0 (
   echo Failed to recompile binary object with target ps_6_0 from %CD%\smoke.hlsl
+  call :cleanup 2>nul
   exit /b 1
 )
 
 dxc.exe smoke.hlsl /D "semantic = SV_Position" /T vs_6_0 /Zi /DDX12 /Fo smoke.cso 1> nul
 if %errorlevel% neq 0 (
   echo Failed to compile smoke.hlsl with command line defines
+  call :cleanup 2>nul
   exit /b 1
 )
 
 dxc.exe smoke.cso /recompile 1> nul
 if %errorlevel% neq 0 (
   echo Failed to recompile smoke.cso with command line defines
+  call :cleanup 2>nul
   exit /b 1
 )
 
@@ -137,71 +161,169 @@ if %errorlevel% neq 0 (
 dxc.exe smoke.cso /dumpbin /Qstrip_debug /Fo nodebug.cso 1>nul
 if %errorlevel% neq 0 (
   echo Failed to strip debug part from DXIL container blob
+  call :cleanup 2>nul
   exit /b 1
 )
 
 dxc.exe smoke.cso /dumpbin /Qstrip_rootsignature /Fo norootsignature.cso 1>nul
 if %errorlevel% neq 0 (
   echo Failed to strip rootsignature from DXIL container blob
+  call :cleanup 2>nul
   exit /b 1
 )
 
 dxc.exe smoke.cso /dumpbin /extractrootsignature /Fo rootsig.cso 1>nul
 if %errorlevel% neq 0 (
   echo Failed to extract rootsignature from DXIL container blob
+  call :cleanup 2>nul
   exit /b 1
 )
 
 dxc.exe norootsignature.cso /dumpbin /setrootsignature rootsig.cso /Fo smoke.cso 1>nul
 if %errorlevel% neq 0 (
   echo Failed to setrootsignature to DXIL conatiner with no root signature
+  call :cleanup 2>nul
+  exit /b 1
+)
+
+dxc.exe "%2"\..\CodeGenHLSL\NonUniform.hlsl /T ps_6_0 /DDX12 /Fo NonUniform.cso 1>nul
+if %errorlevel% neq 0 (
+  echo Failed to compile NonUniform.hlsl
+  call :cleanup 2>nul
+  exit /b 1
+)
+
+dxc.exe NonUniform.cso /dumpbin /Qstrip_rootsignature /Fo NonUniformNoRootSig.cso 1>nul
+if %errorlevel% neq 0 (
+  echo Failed to strip rootsignature from DXIL container blob for NonUniform.cso
+  call :cleanup 2>nul
+  exit /b 1
+)
+
+dxc.exe NonUniform.cso /dumpbin /extractrootsignature /Fo NonUniformRootSig.cso 1>nul
+if %errorlevel% neq 0 (
+  echo Failed to extract rootsignature from DXIL container blob for NonUniform.cso
+  call :cleanup 2>nul
+  exit /b 1
+)
+
+dxc.exe smoke.cso /dumpbin /verifyrootsignature rootsig.cso 1>nul
+if %errorlevel% neq 0 (
+  echo Failed to verify root signature for somke.cso
+  call :cleanup 2>nul
+  exit /b 1
+)
+
+dxc.exe norootsignature.cso /dumpbin /verifyrootsignature rootsig.cso 1>nul
+if %errorlevel% neq 0 (
+  echo Failed to verify root signature for smoke.cso without root signature
+  call :cleanup 2>nul
+  exit /b 1
+)
+
+dxc.exe NonUniform.cso /dumpbin /verifyrootsignature NonUniformRootSig.cso 1>nul
+if %errorlevel% neq 0 (
+  echo Failed to verify root signature for NonUniform.cso
+  call :cleanup 2>nul
+  exit /b 1
+)
+
+dxc.exe NonUniformNoRootSig.cso /dumpbin /verifyrootsignature NonUniformRootSig.cso 1>nul
+if %errorlevel% neq 0 (
+  echo Failed to verify root signature for somke1.cso without root signature
+  call :cleanup 2>nul
+  exit /b 1
+)
+
+dxc.exe NonUniformNoRootSig.cso /dumpbin /verifyrootsignature rootsig.cso 2>nul
+if %errorlevel% equ 0 (
+  echo Verifying invalid root signature for NonUniformNoRootSig.cso should fail but passed
+  call :cleanup 2>nul
+  exit /b 1
+)
+
+dxc.exe norootsignature.cso /dumpbin /verifyrootsignature NonUniformRootSig.cso 2>nul
+if %errorlevel% equ 0 (
+  echo Verifying invalid root signature for norootsignature.cso should fail but passed
+  call :cleanup 2>nul
   exit /b 1
 )
 
 dxc.exe smoke.cso /dumpbin /setrootsignature rootsig.cso /Fo smoke.cso 1>nul
 if %errorlevel% neq 0 (
   echo Failed to setrootsignature to DXIL container that already contains root signature
+  call :cleanup 2>nul
+  exit /b 1
+)
+
+dxc.exe smoke.cso /dumpbin /setrootsignature NonUniformRootSig.cso /Fo smoke.cso 2>nul
+if %errorlevel% equ 0 (
+  echo setrootsignature of invalid root signature should fail but passed
+  call :cleanup 2>nul
+  exit /b 1
+)
+
+dxc.exe %2\..\CodeGenHLSL\Samples\MiniEngine\TextVS.hlsl /Tvs_6_0 /Zi /Fo TextVS.cso 1>nul
+if %errorlevel% neq 0 (
+  echo failed to compile %2\..\CodeGenHLSL\Samples\MiniEngine\TextVS.hlsl
+  call :cleanup 2>nul
+  exit /b 1
+)
+
+dxc.exe smoke.cso /dumpbin /verifyrootsignature TextVS.cso 1>nul
+if %errorlevel% neq 0 ( 
+  echo Verifying valid replacement of root signature failed
+  call :cleanup 2>nul
+  exit /b 1
 )
 
 echo private data > private.txt
 dxc.exe smoke.cso /dumpbin /setprivate private.txt /Fo private.cso 1>nul
 if %errorlevel% neq 0 (
   echo Failed to set private data to DXIL container with no private data
+  call :cleanup 2>nul
   exit /b 1
 )
 
 dxc.exe private.cso /dumpbin /setprivate private.txt /Fo private.cso 1>nul
 if %errorlevel% neq 0 (
   echo Failed to set private data to DXIL container that already contains private data
+  call :cleanup 2>nul
+  exit /b 1
 )
 
 dxc.exe private.cso /dumpbin /Qstrip_priv /Fo noprivate.cso 1>nul
 if %errorlevel% neq 0 (
   echo Failed to strip private data from DXIL container blob
+  call :cleanup 2>nul
   exit /b 1
 )
 
 dxc.exe private.cso /dumpbin /getprivate private1.txt 1>nul
 if %errorlevel% neq 0 (
   echo Failed to get private data from DXIL container blob
+  call :cleanup 2>nul
   exit /b 1
 )
 
 findstr "private data" %CD%\private1.txt 1>nul
 if %errorlevel% neq 0 (
   echo Failed to get private data content from DXIL container blob
+  call :cleanup 2>nul
   exit /b 1
 )
 
 FC smoke.cso noprivate.cso 1>nul
 if %errorlevel% neq 0 (
   echo Appending and removing blob roundtrip failed.
+  call :cleanup 2>nul
   exit /b 1
 )
 
 dxc.exe private.cso /dumpbin /Qstrip_priv /Qstrip_debug /Qstrip_rootsignature /Fo noprivdebugroot.cso 1>nul
 if %errorlevel% neq 0 (
   echo Failed to extract multiple parts from DXIL container blob
+  call :cleanup 2>nul
   exit /b 1
 )
 
@@ -209,6 +331,7 @@ echo Smoke test for dxc.exe shader model upgrade...
 dxc.exe /T ps_5_0 smoke.hlsl 1> nul
 if %errorlevel% neq 0 (
   echo Failed shader model upgrade test - %CD%\dxc.exe /T ps_5_0 %CD%\smoke.hlsl
+  call :cleanup 2>nul
   exit /b 1
 )
 
@@ -216,70 +339,69 @@ echo Smoke test for dxa command line program ...
 dxa.exe smoke.cso -listfiles 1> nul
 if %errorlevel% neq 0 (
   echo Failed to list files from blob 
+  call :cleanup 2>nul
   exit /b 1
 )
 
 dxa.exe smoke.cso -listparts 1> nul
 if %errorlevel% neq 0 (
   echo Failed to list parts from blob
+  call :cleanup 2>nul
   exit /b 1
 )
 
 dxa.exe smoke.cso -extractpart dbgmodule -o smoke.cso.ll 1>nul
 if %errorlevel% neq 0 (
   echo Failed to extract DXIL part from the blob generated by %CD%\smoke.hlsl
+  call :cleanup 2>nul
   exit /b 1
 )
 
 dxa.exe smoke.cso.ll -listfiles 1> nul
 if %errorlevel% neq 0 (
   echo Failed to list files from Dxil part with Dxil with Debug Info
+  call :cleanup 2>nul
   exit /b 1
 )
 
 dxa.exe smoke.cso.ll -extractfile * 1> nul
 if %errorlevel% neq 0 (
   echo Failed to extract files from Dxil part with Dxil with Debug Info
+  call :cleanup 2>nul
   exit /b 1
 )
 
-echo Smoke test for dxopt ...
-dxopt.exe -passes | findstr inline 1>nul
-if %errorlevel% neq 0 (
-  echo Failed to find the inline pass via dxopt -passes
-  exit /b 1
-)
 dxa.exe smoke.cso -extractpart module -o smoke.cso.plain.ll 1>nul
 if %errorlevel% neq 0 (
   echo Failed to extract plain module via dxa.exe smoke.cso -extractpart module -o smoke.cso.plain.ll
-  exit /b 1
-)
-dxopt.exe smoke.cso.plain.ll -o=smoke.cso.inlined.ll -inline
-if %errorlevel% neq 0 (
-  echo Failed to run an inline pass via dxopt.exe smoke.cso.ll -o=smoke.cso.inlined.ll -inline
-  exit /b 1
-)
-dxc.exe -dumpbin smoke.cso.inlined.ll 1>nul
-if %errorlevel% neq 0 (
-  echo Failed to dump the inlined file.
+  call :cleanup 2>nul
   exit /b 1
 )
 
-rem Clean up.
+call :cleanup
+exit /b 0
+
+:cleanup
 del %CD%\preprocessed.hlsl
 del %CD%\smoke.hlsl.c
 del %CD%\smoke.hlsl.d
 del %CD%\smoke.hlsl.e
 del %CD%\smoke.hlsl.h
 del %CD%\smoke.cso
+del %CD%\NonUniform.cso
 del %CD%\private.cso
 del %CD%\private.txt
 del %CD%\private1.txt
 del %CD%\noprivate.cso
 del %CD%\nodebug.cso
+del %CD%\rootsig.cso
+del %CD%\NonUniformRootSig.cso
 del %CD%\noprivdebugroot.cso
 del %CD%\norootsignature.cso
-del %CD%\smoke.cso.inlined.ll
+del %CD%\NonUniformNoRootSig.cso
+del %CD%\TextVS.cso
 del %CD%\smoke.cso.plain.ll
+del %CD%\smoke.cso.ll
 
 exit /b 0
+

--- a/utils/hct/smoke.hlsl
+++ b/utils/hct/smoke.hlsl
@@ -1,12 +1,13 @@
+int g;
 #ifndef semantic
 #define semantic SV_Target
 #endif
 #ifdef DX12
-#define RS ""
+#define RS "CBV(b0)"
 [RootSignature ( RS )]
 #endif
 
 float4 main() : semantic
 {
-  return 0;
+  return g;
 }


### PR DESCRIPTION
- distinguish stream type (stdout, stderr) when printing to console
- verifyrootsignature option returns correct errorlevel
- adding more test cases to hcttest for verifyrootsignature option
- enable verifyrootsignature option when dxil.dll not present