### PR TITLE
Fix barrier for allowed ops and flags by shader kind

### DIFF
--- a/docs/DXIL.rst
+++ b/docs/DXIL.rst
@@ -3063,6 +3063,7 @@ INSTR.BARRIERMODEFORNONCS                 sync in a non-Compute/Amplification/Me
 INSTR.BARRIERMODENOMEMORY                 sync must include some form of memory barrier - _u (UAV) and/or _g (Thread Group Shared Memory).  Only _t (thread group sync) is optional.
 INSTR.BARRIERMODEUSELESSUGROUP            sync can't specify both _ugroup and _uglobal. If both are needed, just specify _uglobal.
 INSTR.BARRIERNONCONSTANTFLAGARGUMENT      Memory type, access, or sync flag is not constant
+INSTR.BARRIERREQUIRESNODE                 sync in a non-Node Shader must not sync node record memory.
 INSTR.BUFFERUPDATECOUNTERONRESHASCOUNTER  BufferUpdateCounter valid only when HasCounter is true.
 INSTR.BUFFERUPDATECOUNTERONUAV            BufferUpdateCounter valid only on UAV.
 INSTR.CALLOLOAD                           Call to DXIL intrinsic must match overload signature

--- a/include/dxc/DXIL/DxilConstants.h
+++ b/include/dxc/DXIL/DxilConstants.h
@@ -1481,6 +1481,7 @@ enum class AtomicBinOpCode : unsigned {
 
 // Barrier/fence modes.
 enum class BarrierMode : unsigned {
+  Invalid = 0,
   SyncThreadGroup = 0x00000001,
   UAVFenceGlobal = 0x00000002,
   UAVFenceThreadGroup = 0x00000004,

--- a/include/dxc/DXIL/DxilInstructions.h
+++ b/include/dxc/DXIL/DxilInstructions.h
@@ -8856,6 +8856,15 @@ struct DxilInst_BarrierByNodeRecordHandle {
   void set_object(llvm::Value *val) { Instr->setOperand(1, val); }
   llvm::Value *get_SemanticFlags() const { return Instr->getOperand(2); }
   void set_SemanticFlags(llvm::Value *val) { Instr->setOperand(2, val); }
+  int32_t get_SemanticFlags_val() const {
+    return (int32_t)(llvm::dyn_cast<llvm::ConstantInt>(Instr->getOperand(2))
+                         ->getZExtValue());
+  }
+  void set_SemanticFlags_val(int32_t val) {
+    Instr->setOperand(2, llvm::Constant::getIntegerValue(
+                             llvm::IntegerType::get(Instr->getContext(), 32),
+                             llvm::APInt(32, (uint64_t)val)));
+  }
 };
 
 /// This instruction Creates a handle to a NodeOutput

--- a/include/dxc/DXIL/DxilOperations.h
+++ b/include/dxc/DXIL/DxilOperations.h
@@ -125,6 +125,10 @@ public:
   static bool IsDxilOpWave(OpCode C);
   static bool IsDxilOpGradient(OpCode C);
   static bool IsDxilOpFeedback(OpCode C);
+  static bool IsDxilOpBarrier(OpCode C);
+  static bool BarrierRequiresGroup(const llvm::CallInst *CI);
+  static bool BarrierRequiresNode(const llvm::CallInst *CI);
+  static DXIL::BarrierMode TranslateToBarrierMode(const llvm::CallInst *CI);
   static bool IsDxilOpTypeName(llvm::StringRef name);
   static bool IsDxilOpType(llvm::StructType *ST);
   static bool IsDupDxilOpType(llvm::StructType *ST);

--- a/lib/HLSL/DxilValidation.cpp
+++ b/lib/HLSL/DxilValidation.cpp
@@ -2302,7 +2302,13 @@ static void ValidateDxilOperationCallInProfile(CallInst *CI,
     ValidateBarrierFlagArg(ValCtx, CI, DI.get_SemanticFlags(),
                            (unsigned)hlsl::DXIL::BarrierSemanticFlag::ValidMask,
                            "semantic", "BarrierByMemoryType");
-
+    if (!isLibFunc && shaderKind != DXIL::ShaderKind::Node &&
+        OP::BarrierRequiresNode(CI)) {
+      ValCtx.EmitInstrError(CI, ValidationRule::InstrBarrierRequiresNode);
+    }
+    if (!isCSLike && !isLibFunc && OP::BarrierRequiresGroup(CI)) {
+      ValCtx.EmitInstrError(CI, ValidationRule::InstrBarrierModeForNonCS);
+    }
   } break;
   case DXIL::OpCode::BarrierByNodeRecordHandle:
   case DXIL::OpCode::BarrierByMemoryHandle: {
@@ -2313,6 +2319,13 @@ static void ValidateDxilOperationCallInProfile(CallInst *CI,
     ValidateBarrierFlagArg(ValCtx, CI, DIMH.get_SemanticFlags(),
                            (unsigned)hlsl::DXIL::BarrierSemanticFlag::ValidMask,
                            "semantic", opName);
+    if (!isLibFunc && shaderKind != DXIL::ShaderKind::Node &&
+        OP::BarrierRequiresNode(CI)) {
+      ValCtx.EmitInstrError(CI, ValidationRule::InstrBarrierRequiresNode);
+    }
+    if (!isCSLike && !isLibFunc && OP::BarrierRequiresGroup(CI)) {
+      ValCtx.EmitInstrError(CI, ValidationRule::InstrBarrierModeForNonCS);
+    }
   } break;
   case DXIL::OpCode::CreateHandleForLib:
     if (!ValCtx.isLibProfile) {

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/rdat_mintarget/sm68_barriers.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/rdat_mintarget/sm68_barriers.hlsl
@@ -8,10 +8,10 @@
 RWByteAddressBuffer BAB : register(u1, space0);
 
 // RDAT-LABEL: UnmangledName: "node_barrier"
-// RDAT:   FeatureInfo1: 0
-// RDAT:   FeatureInfo2: 0
-// MinShaderTarget: (Node(15) << 16) + (SM 6.8 ((6 << 4) + 8)) = 0xF0068 = 983144
-// RDAT: MinShaderTarget: 983144
+// RDAT: FeatureInfo1: 0
+// RDAT: FeatureInfo2: 0
+// RDAT: ShaderStageFlag: (Node)
+// RDAT: MinShaderTarget: 0xf0068
 
 [shader("node")]
 [NodeLaunch("broadcasting")]
@@ -23,32 +23,54 @@ void node_barrier() {
 }
 
 // RDAT-LABEL: UnmangledName: "fn_barrier_device1"
-// RDAT:   FeatureInfo1: 0
-// RDAT:   FeatureInfo2: 0
-// Compute(5), Library(6), Mesh(13), Amplification(14), Node(15) = 0xE060 = 57440
-// RDAT: ShaderStageFlag: 57440
-// MinShaderTarget: (Library(6) << 16) + (SM 6.8 ((6 << 4) + 8)) = 60068 = 393320
-// RDAT: MinShaderTarget: 393320
+// RDAT: FeatureInfo1: 0
+// RDAT: FeatureInfo2: 0
+// RDAT: ShaderStageFlag: (Pixel | Vertex | Geometry | Hull | Domain | Compute | Library | RayGeneration | Intersection | AnyHit | ClosestHit | Miss | Callable | Mesh | Amplification | Node)
+// RDAT: MinShaderTarget: 0x60060
 
 [noinline] export
 void fn_barrier_device1() {
   Barrier(UAV_MEMORY, DEVICE_SCOPE);
 }
 
+// RDAT-LABEL: UnmangledName: "fn_barrier_device2"
+// RDAT: FeatureInfo1: 0
+// RDAT: FeatureInfo2: 0
+// RDAT: ShaderStageFlag: (Pixel | Vertex | Geometry | Hull | Domain | Compute | Library | RayGeneration | Intersection | AnyHit | ClosestHit | Miss | Callable | Mesh | Amplification | Node)
+// RDAT: MinShaderTarget: 0x60068
+
 [noinline] export
 void fn_barrier_device2() {
   Barrier(BAB, DEVICE_SCOPE);
 }
+
+// RDAT-LABEL: UnmangledName: "fn_barrier_group1"
+// RDAT: FeatureInfo1: 0
+// RDAT: FeatureInfo2: 0
+// RDAT: ShaderStageFlag: (Compute | Library | Mesh | Amplification | Node)
+// RDAT: MinShaderTarget: 0x60060
 
 [noinline] export
 void fn_barrier_group1() {
   Barrier(GROUP_SHARED_MEMORY, GROUP_SYNC | GROUP_SCOPE);
 }
 
+// RDAT-LABEL: UnmangledName: "fn_barrier_group2"
+// RDAT: FeatureInfo1: 0
+// RDAT: FeatureInfo2: 0
+// RDAT: ShaderStageFlag: (Compute | Library | Mesh | Amplification | Node)
+// RDAT: MinShaderTarget: 0x60068
+
 [noinline] export
 void fn_barrier_group2() {
   Barrier(BAB, GROUP_SYNC | GROUP_SCOPE);
 }
+
+// RDAT-LABEL: UnmangledName: "fn_barrier_node1"
+// RDAT: FeatureInfo1: 0
+// RDAT: FeatureInfo2: 0
+// RDAT: ShaderStageFlag: (Library | Node)
+// RDAT: MinShaderTarget: 0x60068
 
 [noinline] export
 void fn_barrier_node1() {
@@ -56,12 +78,10 @@ void fn_barrier_node1() {
 }
 
 // RDAT-LABEL: UnmangledName: "node_barrier_device_in_call"
-// RDAT:   FeatureInfo1: 0
-// RDAT:   FeatureInfo2: 0
-// Node(15) = 0x8000 = 32768
-// RDAT: ShaderStageFlag: 32768
-// MinShaderTarget: (Node(15) << 16) + (SM 6.8 ((6 << 4) + 8)) = 0xF0068 = 983144
-// RDAT: MinShaderTarget: 983144
+// RDAT: FeatureInfo1: 0
+// RDAT: FeatureInfo2: 0
+// RDAT: ShaderStageFlag: (Node)
+// RDAT: MinShaderTarget: 0xf0068
 
 [shader("node")]
 [NodeLaunch("broadcasting")]

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/rdat_mintarget/sm68_barriers.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/rdat_mintarget/sm68_barriers.hlsl
@@ -1,0 +1,73 @@
+// RUN: %dxilver 1.8 | %dxc -T lib_6_8 %s | %D3DReflect %s | %FileCheck %s -check-prefixes=RDAT
+
+// Check that stage flags are set correctly for different barrier modes with
+// new the SM 6.8 barrier intrinsics.
+
+// RDAT: FunctionTable[{{.*}}] = {
+
+RWByteAddressBuffer BAB : register(u1, space0);
+
+// RDAT-LABEL: UnmangledName: "node_barrier"
+// RDAT:   FeatureInfo1: 0
+// RDAT:   FeatureInfo2: 0
+// MinShaderTarget: (Node(15) << 16) + (SM 6.8 ((6 << 4) + 8)) = 0xF0068 = 983144
+// RDAT: MinShaderTarget: 983144
+
+[shader("node")]
+[NodeLaunch("broadcasting")]
+[NodeDispatchGrid(1, 1, 1)]
+[NumThreads(1,1,1)]
+void node_barrier() {
+  GroupMemoryBarrierWithGroupSync();
+  BAB.Store(0, 0);
+}
+
+// RDAT-LABEL: UnmangledName: "fn_barrier_device1"
+// RDAT:   FeatureInfo1: 0
+// RDAT:   FeatureInfo2: 0
+// Compute(5), Library(6), Mesh(13), Amplification(14), Node(15) = 0xE060 = 57440
+// RDAT: ShaderStageFlag: 57440
+// MinShaderTarget: (Library(6) << 16) + (SM 6.8 ((6 << 4) + 8)) = 60068 = 393320
+// RDAT: MinShaderTarget: 393320
+
+[noinline] export
+void fn_barrier_device1() {
+  Barrier(UAV_MEMORY, DEVICE_SCOPE);
+}
+
+[noinline] export
+void fn_barrier_device2() {
+  Barrier(BAB, DEVICE_SCOPE);
+}
+
+[noinline] export
+void fn_barrier_group1() {
+  Barrier(GROUP_SHARED_MEMORY, GROUP_SYNC | GROUP_SCOPE);
+}
+
+[noinline] export
+void fn_barrier_group2() {
+  Barrier(BAB, GROUP_SYNC | GROUP_SCOPE);
+}
+
+[noinline] export
+void fn_barrier_node1() {
+  Barrier(NODE_INPUT_MEMORY, GROUP_SYNC | GROUP_SCOPE);
+}
+
+// RDAT-LABEL: UnmangledName: "node_barrier_device_in_call"
+// RDAT:   FeatureInfo1: 0
+// RDAT:   FeatureInfo2: 0
+// Node(15) = 0x8000 = 32768
+// RDAT: ShaderStageFlag: 32768
+// MinShaderTarget: (Node(15) << 16) + (SM 6.8 ((6 << 4) + 8)) = 0xF0068 = 983144
+// RDAT: MinShaderTarget: 983144
+
+[shader("node")]
+[NodeLaunch("broadcasting")]
+[NodeDispatchGrid(1, 1, 1)]
+[NumThreads(1,1,1)]
+void node_barrier_device_in_call() {
+  fn_barrier_device1();
+  BAB.Store(0, 0);
+}

--- a/tools/clang/test/HLSLFileCheck/validation/barrier/barrier-group-in-ps1.ll
+++ b/tools/clang/test/HLSLFileCheck/validation/barrier/barrier-group-in-ps1.ll
@@ -1,0 +1,41 @@
+; RUN: %dxilver 1.8 | %dxv %s | FileCheck %s
+
+; CHECK-DAG: Function: main: error: sync in a non-Compute/Amplification/Mesh/Node Shader must only sync UAV (sync_uglobal).
+; CHECK-DAG: note: at 'call void @dx.op.barrierByMemoryType(i32 244, i32 3, i32 3)' in block '#0' of function 'main'.
+
+target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
+target triple = "dxil-ms-dx"
+
+define void @main() {
+  ; MemoryTypeFlags = UAV_MEMORY
+  ; SemanticFlags = GROUP_SYNC | GROUP_SCOPE
+  call void @dx.op.barrierByMemoryType(i32 244, i32 1, i32 3)  ; BarrierByMemoryType(MemoryTypeFlags,SemanticFlags)
+  ret void
+}
+
+; Function Attrs: nounwind
+declare void @dx.op.storeOutput.f32(i32, i32, i32, i8, float) #0
+
+; Function Attrs: noduplicate nounwind
+declare void @dx.op.barrierByMemoryType(i32, i32, i32) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { noduplicate nounwind }
+
+!llvm.ident = !{!0}
+!dx.version = !{!1}
+!dx.valver = !{!1}
+!dx.shaderModel = !{!2}
+!dx.viewIdState = !{!3}
+!dx.entryPoints = !{!4}
+
+!0 = !{!"dxc(private) 1.7.0.4429 (rdat-minsm-check-flags, 9d3b6ba57)"}
+!1 = !{i32 1, i32 8}
+!2 = !{!"ps", i32 6, i32 8}
+!3 = !{[2 x i32] [i32 0, i32 4]}
+!4 = !{void ()* @main, !"main", !5, null, null}
+!5 = !{null, !6, null}
+!6 = !{!7}
+!7 = !{i32 0, !"SV_Target", i8 9, i8 16, !8, i8 0, i32 1, i8 4, i32 0, i8 0, !9}
+!8 = !{i32 0}
+!9 = !{i32 3, i32 15}

--- a/tools/clang/test/HLSLFileCheck/validation/barrier/barrier-group-in-ps2.ll
+++ b/tools/clang/test/HLSLFileCheck/validation/barrier/barrier-group-in-ps2.ll
@@ -1,0 +1,64 @@
+; RUN: %dxilver 1.8 | %dxv %s | FileCheck %s
+
+; CHECK-DAG: Function: main: error: sync in a non-Compute/Amplification/Mesh/Node Shader must only sync UAV (sync_uglobal).
+; CHECK-DAG: note: at 'call void @dx.op.barrierByMemoryHandle(i32 245, %dx.types.Handle %2, i32 3)' in block '#0' of function 'main'.
+
+target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
+target triple = "dxil-ms-dx"
+
+%dx.types.Handle = type { i8* }
+%dx.types.ResBind = type { i32, i32, i32, i8 }
+%dx.types.ResourceProperties = type { i32, i32 }
+%"class.RWBuffer<vector<float, 4> >" = type { <4 x float> }
+
+define void @main() {
+  %1 = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 0, i32 0, i32 0, i8 1 }, i32 0, i1 false)  ; CreateHandleFromBinding(bind,index,nonUniformIndex)
+  %2 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %1, %dx.types.ResourceProperties { i32 4106, i32 1033 })  ; AnnotateHandle(res,props)  resource: RWTypedBuffer<4xF32>
+  ; GROUP_SYNC | GROUP_SCOPE = 3
+  call void @dx.op.barrierByMemoryHandle(i32 245, %dx.types.Handle %2, i32 3)  ; BarrierByMemoryHandle(object,SemanticFlags)
+  call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float 0.000000e+00)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+  call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 1, float 0.000000e+00)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+  call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 2, float 0.000000e+00)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+  call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 3, float 0.000000e+00)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+  ret void
+}
+
+; Function Attrs: nounwind
+declare void @dx.op.storeOutput.f32(i32, i32, i32, i8, float) #0
+
+; Function Attrs: noduplicate nounwind
+declare void @dx.op.barrierByMemoryHandle(i32, %dx.types.Handle, i32) #1
+
+; Function Attrs: nounwind readnone
+declare %dx.types.Handle @dx.op.annotateHandle(i32, %dx.types.Handle, %dx.types.ResourceProperties) #2
+
+; Function Attrs: nounwind readnone
+declare %dx.types.Handle @dx.op.createHandleFromBinding(i32, %dx.types.ResBind, i32, i1) #2
+
+attributes #0 = { nounwind }
+attributes #1 = { noduplicate nounwind }
+attributes #2 = { nounwind readnone }
+
+!llvm.ident = !{!0}
+!dx.version = !{!1}
+!dx.valver = !{!1}
+!dx.shaderModel = !{!2}
+!dx.resources = !{!3}
+!dx.viewIdState = !{!7}
+!dx.entryPoints = !{!8}
+
+!0 = !{!"dxc(private) 1.7.0.4429 (rdat-minsm-check-flags, 9d3b6ba57)"}
+!1 = !{i32 1, i32 8}
+!2 = !{!"ps", i32 6, i32 8}
+!3 = !{null, !4, null, null}
+!4 = !{!5}
+!5 = !{i32 0, %"class.RWBuffer<vector<float, 4> >"* undef, !"", i32 0, i32 0, i32 1, i32 10, i1 false, i1 false, i1 false, !6}
+!6 = !{i32 0, i32 9}
+!7 = !{[2 x i32] [i32 0, i32 4]}
+!8 = !{void ()* @main, !"main", !9, !3, !14}
+!9 = !{null, !10, null}
+!10 = !{!11}
+!11 = !{i32 0, !"SV_Target", i8 9, i8 16, !12, i8 0, i32 1, i8 4, i32 0, i8 0, !13}
+!12 = !{i32 0}
+!13 = !{i32 3, i32 15}
+!14 = !{i32 0, i64 8589934592}

--- a/tools/clang/test/HLSLFileCheck/validation/barrier/barrier-node-in-compute1.ll
+++ b/tools/clang/test/HLSLFileCheck/validation/barrier/barrier-node-in-compute1.ll
@@ -1,0 +1,39 @@
+; RUN: %dxilver 1.8 | %dxv %s | FileCheck %s
+
+; CHECK-DAG: Function: main: error: sync in a non-Node Shader must not sync node record memory.
+; CHECK-DAG: note: at 'call void @dx.op.barrierByMemoryType(i32 244, i32 7, i32 4)' in block '#0' of function 'main'.
+; CHECK-DAG: Function: main: error: sync in a non-Node Shader must not sync node record memory.
+; CHECK-DAG: note: at 'call void @dx.op.barrierByMemoryType(i32 244, i32 8, i32 4)' in block '#0' of function 'main'.
+
+target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
+target triple = "dxil-ms-dx"
+
+define void @main() {
+  ; Invalid because NODE_INPUT_MEMORY is not applicable in non-Node Shaders
+  ; MemoryTypeFlags = NODE_INPUT_MEMORY
+  ; SemanticFlags = GROUP_SCOPE
+  call void @dx.op.barrierByMemoryType(i32 244, i32 4, i32 4)  ; BarrierByMemoryType(MemoryTypeFlags,SemanticFlags)
+  ; Invalid because NODE_OUTPUT_MEMORY is not applicable in non-Node Shaders
+  ; MemoryTypeFlags = NODE_OUTPUT_MEMORY
+  ; SemanticFlags = GROUP_SCOPE
+  call void @dx.op.barrierByMemoryType(i32 244, i32 8, i32 2)  ; BarrierByMemoryType(MemoryTypeFlags,SemanticFlags)
+  ret void
+}
+
+; Function Attrs: noduplicate nounwind
+declare void @dx.op.barrierByMemoryType(i32, i32, i32) #0
+
+attributes #0 = { noduplicate nounwind }
+
+!llvm.ident = !{!0}
+!dx.version = !{!1}
+!dx.valver = !{!1}
+!dx.shaderModel = !{!2}
+!dx.entryPoints = !{!3}
+
+!0 = !{!"dxc(private) 1.7.0.4429 (rdat-minsm-check-flags, 9d3b6ba57)"}
+!1 = !{i32 1, i32 8}
+!2 = !{!"cs", i32 6, i32 8}
+!3 = !{void ()* @main, !"main", null, null, !4}
+!4 = !{i32 4, !5}
+!5 = !{i32 8, i32 8, i32 1}

--- a/tools/clang/test/HLSLFileCheck/validation/barrier/barrier-node-in-compute2.ll
+++ b/tools/clang/test/HLSLFileCheck/validation/barrier/barrier-node-in-compute2.ll
@@ -1,0 +1,32 @@
+; RUN: %dxilver 1.8 | %dxv %s | FileCheck %s
+
+; CHECK: Function: main: error: Opcode BarrierByNodeRecordHandle not valid in shader model cs_6_8.
+; CHECK: note: at 'call void @dx.op.barrierByNodeRecordHandle(i32 246, %dx.types.NodeRecordHandle zeroinitializer, i32 4)' in block '#0' of function 'main'.
+
+target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
+target triple = "dxil-ms-dx"
+
+%dx.types.NodeRecordHandle = type { i8* }
+
+define void @main() {
+  call void @dx.op.barrierByNodeRecordHandle(i32 246, %dx.types.NodeRecordHandle zeroinitializer, i32 4)
+  ret void
+}
+
+; Function Attrs: noduplicate nounwind
+declare void @dx.op.barrierByNodeRecordHandle(i32, %dx.types.NodeRecordHandle, i32) #0
+
+attributes #0 = { noduplicate nounwind }
+
+!llvm.ident = !{!0}
+!dx.version = !{!1}
+!dx.valver = !{!1}
+!dx.shaderModel = !{!2}
+!dx.entryPoints = !{!3}
+
+!0 = !{!"dxc(private) 1.7.0.4429 (rdat-minsm-check-flags, 9d3b6ba57)"}
+!1 = !{i32 1, i32 8}
+!2 = !{!"cs", i32 6, i32 8}
+!3 = !{void ()* @main, !"main", null, null, !4}
+!4 = !{i32 4, !5}
+!5 = !{i32 8, i32 8, i32 1}

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -87,6 +87,7 @@ class db_dxil_inst(object):
         self.is_feedback = False  # whether this is a sampler feedback op
         self.is_wave = False  # whether this requires in-wave, cross-lane functionality
         self.requires_uniform_inputs = False  # whether this operation requires that all of its inputs are uniform across the wave
+        self.is_barrier = False  # whether this is a barrier operation
         self.shader_stages = ()  # shader stages to which this applies, empty for all.
         self.shader_model = 6, 0  # minimum shader model required
         self.inst_helper_prefix = None
@@ -356,6 +357,12 @@ class db_dxil(object):
             ","
         ):
             self.name_idx[i].category = "Synchronization"
+        for (
+            i
+        ) in "Barrier,BarrierByMemoryType,BarrierByMemoryHandle,BarrierByNodeRecordHandle".split(
+            ","
+        ):
+            self.name_idx[i].is_barrier = True
         for i in "CalculateLOD,DerivCoarseX,DerivCoarseY,DerivFineX,DerivFineY".split(
             ","
         ):
@@ -480,9 +487,7 @@ class db_dxil(object):
                 "closesthit",
             )
         for i in "GeometryIndex".split(","):
-            self.name_idx[
-                i
-            ].category = (
+            self.name_idx[i].category = (
                 "Raytracing object space uint System Values, raytracing tier 1.1"
             )
             self.name_idx[i].shader_model = 6, 5
@@ -577,9 +582,7 @@ class db_dxil(object):
             self.name_idx[i].shader_model = 6, 3
             self.name_idx[i].shader_stages = ("library", "intersection")
         for i in "CreateHandleForLib".split(","):
-            self.name_idx[
-                i
-            ].category = (
+            self.name_idx[i].category = (
                 "Library create handle from resource struct (like HL intrinsic)"
             )
             self.name_idx[i].shader_model = 6, 3
@@ -685,12 +688,20 @@ class db_dxil(object):
             self.name_idx[i].category = "Work Graph intrinsics"
             self.name_idx[i].shader_model = 6, 8
             self.name_idx[i].shader_stages = ("node",)
-        for (
-            i
-        ) in "BarrierByMemoryType,BarrierByMemoryHandle,BarrierByNodeRecordHandle".split(
-            ","
-        ):  # included in Synchronization category
+        for i in "BarrierByMemoryType".split(","):
+            # included in Synchronization category
+            self.name_idx[i].is_barrier = True
             self.name_idx[i].shader_model = 6, 8
+            self.name_idx[i].shader_model_translated = 6, 0
+        for i in "BarrierByMemoryHandle".split(","):
+            # included in Synchronization category
+            self.name_idx[i].is_barrier = True
+            self.name_idx[i].shader_model = 6, 8
+        for i in "BarrierByNodeRecordHandle".split(","):
+            # included in Synchronization category
+            self.name_idx[i].is_barrier = True
+            self.name_idx[i].shader_model = 6, 8
+            self.name_idx[i].shader_stages = ("node",)
         for i in "SampleCmpBias,SampleCmpGrad".split(","):
             self.name_idx[i].category = "Comparison Samples"
             self.name_idx[i].shader_model = 6, 8
@@ -5368,6 +5379,7 @@ class db_dxil(object):
                     3, "i32", "SemanticFlags", "semantic flags", is_const=True
                 ),
             ],
+            counters=("barrier",),
         )
         next_op_idx += 1
         self.add_dxil_op(
@@ -5384,6 +5396,7 @@ class db_dxil(object):
                     3, "i32", "SemanticFlags", "semantic flags", is_const=True
                 ),
             ],
+            counters=("barrier",),
         )
         next_op_idx += 1
         self.add_dxil_op(
@@ -5396,8 +5409,11 @@ class db_dxil(object):
             [
                 retvoid_param,
                 db_dxil_param(2, "noderecordhandle", "object", "handle of object"),
-                db_dxil_param(3, "i32", "SemanticFlags", "semantic flags"),
+                db_dxil_param(
+                    3, "i32", "SemanticFlags", "semantic flags", is_const=True
+                ),
             ],
+            counters=("barrier",),
         )
         next_op_idx += 1
         self.add_dxil_op(
@@ -7397,6 +7413,10 @@ class db_dxil(object):
         self.add_valrule(
             "Instr.BarrierNonConstantFlagArgument",
             "Memory type, access, or sync flag is not constant",
+        )
+        self.add_valrule(
+            "Instr.BarrierRequiresNode",
+            "sync in a non-Node Shader must not sync node record memory.",
         )
         self.add_valrule(
             "Instr.WriteMaskForTypedUAVStore",


### PR DESCRIPTION
New barrier operations lacked validation and for RDAT info: had incorrect min target and shader stage flags.

This change adds some common code to:
- identify barrier DXIL operations with new is_barrier in hctdb.py and generated OP::IsDxilOpBarrier.
- identify when a barrier op requires shader stage with group (compute-like stage), or when it requires node memory.
- translate to original BarrierMode when compatible; adds BarrierMode::Invalid to identify invalid cases.
Then uses common code to:
- properly set min shader model and compatible shader stage flags.
- validate barrier in shader stage.